### PR TITLE
Expose getAppAPI's SDK on self as global

### DIFF
--- a/exposeAPI/getApiApp.js
+++ b/exposeAPI/getApiApp.js
@@ -3,6 +3,7 @@
 
     module.exports = {
         editorReady: async function (editorSDK, appDefinitionId) {
+            self.sdk = editorSDK;
             const appPublicAPI = await editorSDK.document.application.getPublicAPI(appDefinitionId, {appDefinitionId: '151294ae-dbdf-1943-4d8c-d6bdadf56ec2'});
             await appPublicAPI.sendLog("Got it");
         },


### PR DESCRIPTION
In the worker, each app gets its own instance of the SDK.
If you want to use the sdk locally, you can either create your own instance of the sdk (which is a little complicated) or just use one of the existing ones. To do that, you expose it on `self` (which is the same as `window`, except web workers don't have `window`)
And then to use the SDK from the console you can run `self.sdk.someNamespace.someMethod()` (e.g. `self.sdk.editor.openModalPanel('token', {url: '...'})`